### PR TITLE
Remove transifex-client from requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,6 +21,4 @@ lxml>=3.4.4,<4.0.0
 path.py>=8.2.1,<9.0.0
 python-dateutil>=2.1,<3.0
 pytz
-six==1.11.0
-transifex-client>=0.13.6
 voluptuous>=0.10.5,<1.0.0


### PR DESCRIPTION
In https://github.com/Edraak/edx-ora2/pull/4 ; I fixed some dependencies to have the `make install` successful. I also added `transifex-client` and `six` as they are required by update translation commands.

The pin created a conflict in `edraak-platform` because the later uses **transifex-client version 0.13.3** not **0.13.6**. So `transifex-client` pin should not be included in this repo because `edraak-platform` includes it