### PR TITLE
Fix Failing Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - python: 2.7
       env: TOXENV=js
 before_install:
-  - "pip install -U pip"
+  - "pip install pip==19.0.3"
   - sudo rm -f /etc/boto.cfg
 cache:
     directories:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,24 +1,25 @@
 # edX Internal Requirements
 edx-i18n-tools==0.4.6
-edx-submissions>=2.0.12,<3.0.0
+edx-submissions>=2.0.12,<=2.1.1
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 git+https://github.com/edx/XBlock.git@xblock-1.0.1#egg=XBlock==1.0.1
 git+https://github.com/edx/xblock-sdk.git@v0.1.4#egg=xblock-sdk==0.1.4
 
+
 # Third Party Requirements
 bleach==1.4
 html5lib==0.999
-boto>=2.39.0,<3.0.0
-python-swiftclient>=3.1.0,<4.0.0
-defusedxml>=0.4.1,<1.0.0
-django-model-utils>=2.3.1
-dogapi>=1.2.1,<2.0.0
-jsonfield>=2.0.2,<3.0.0
-lazy>=1.1,<2.0
-libsass>=0.10.0,<1.0.0
-loremipsum>=1.0.5,<2.0.0
-lxml>=3.4.4,<4.0.0
-path.py>=8.2.1,<9.0.0
-python-dateutil>=2.1,<3.0
-pytz
-voluptuous>=0.10.5,<1.0.0
+boto>=2.39.0,<=2.49.0
+python-swiftclient>=3.1.0,<=3.7.0
+defusedxml>=0.4.1,<=0.6.0
+django-model-utils>=2.3.1,<=3.1.2
+dogapi>=1.2.1,<=1.11.1
+jsonfield==2.0.2
+lazy>=1.1,<=1.4
+libsass>=0.10.0,<=0.18.0
+loremipsum>=1.0.5,<=1.0.5
+lxml>=3.4.4,<=3.8.0
+path.py>=8.2.1,<=8.3
+python-dateutil>=2.1,<=2.8.0
+pytz==2019.1
+voluptuous>=0.10.5,<=0.11.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -1,3 +1,16 @@
 pep8==1.7.0
 
+# edx_lint
 git+https://github.com/edx/edx-lint.git@0.5.4#egg=edx_lint==0.5.4
+pylint==1.7.1
+configparser==3.7.4
+isort==4.3.18
+mccabe==0.6.1
+singledispatch==3.4.0.3
+wrapt==1.11.1
+lazy-object-proxy==1.3.1
+enum34==1.1.6
+astroid==1.5.2
+pylint-celery==0.3
+pylint-plugin-utils==0.5
+futures==3.2.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,7 @@
 
 coverage==4.4.1
 ddt==1.0.0
-django-nose>=1.4.1,<2.0.0
+django-nose>=1.4.1,<=1.4.6
 factory_boy==2.8.1
 freezegun==0.3.9
 mock==2.0.0
@@ -10,4 +10,34 @@ moto==0.4.31
 nose==1.3.7
 tox==2.7.0
 
+# django-pyfs
 git+https://github.com/edx/django-pyfs.git@1.0.6#egg=django-pyfs==1.0.6
+fs==2.4.4
+appdirs==1.4.3
+backports.os==0.1.1
+future==0.17.1
+enum34==1.1.6
+pytz==2019.1
+six==1.12.0
+typing==3.6.6
+
+# factory-boy
+Faker==1.0.5
+ipaddress==1.0.22
+text-unidecode==1.2
+
+# dogapi
+decorator==4.4.0
+simplejson==3.16.0
+
+# xblock-sdk
+binaryornot==0.4.4
+cookiecutter==0.9.0
+funcsigs==1.0.2
+Jinja2==2.10.1
+MarkupSafe==1.1.1
+pbr==5.2.0
+pypng==0.0.19
+PyYAML==5.1
+web-fragments==0.3.0
+WebOb==1.8.5

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,0 +1,15 @@
+# tox
+tox==2.7.0
+pluggy==0.9.0
+py==1.8.0
+virtualenv==16.5.0
+
+# coveralls
+coveralls==1.7.0
+coverage==4.4.1
+docopt==0.6.2
+requests==2.21.0
+certifi==2019.3.9
+chardet==3.0.4
+idna==2.8
+urllib3==1.24.3

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,11 @@ envlist = py27-django{18,111}
 whitelist_externals = make
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
-    coveralls
     -rrequirements/base.txt
     -rrequirements/test.txt
-    django18: django>=1.8,<1.9
-    django111: django>=1.11,<2.0
+    -rrequirements/tox.txt
+    django18: django==1.8.19
+    django111: django==1.11.2
 commands =
     make test-python
 


### PR DESCRIPTION
Some un-pinned packages are making troubles with travis ci:
- Pin `pip` to version `19.0.3` to avoid any future failure caused by Python2.7 drop of support
- Pin package versions in `base.txt` to the version used currently in `edx-platform` (patched in https://github.com/Edraak/edx-ora2/pull/8 and https://github.com/Edraak/edx-ora2/pull/9)
- Pin other packages in `test.txt`, `quality.txt`, `tox.txt` and `tox.ini` to the last passed versions as in https://github.com/Edraak/edx-ora2/pull/5

---------------------
See the patches for this PR in https://github.com/Edraak/edx-ora2/pull/8 and https://github.com/Edraak/edx-ora2/pull/9